### PR TITLE
added initial_timestamp_mellowtel and lifetime_total_count_mellowtel local variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mellowtel",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const MELLOWTEL_VERSION: string = "1.2.2";
+export const MELLOWTEL_VERSION: string = "1.2.3";
 export const MAX_PARALLEL_EXECUTIONS: number = 4;
 export const MAX_QUEUE_SIZE: number = 12;
 export const LIFESPAN_IFRAME: number = 1000 * 60 * 1.5; // 1.5 minutes

--- a/src/local-rate-limiting/rate-limiter.ts
+++ b/src/local-rate-limiting/rate-limiter.ts
@@ -43,7 +43,7 @@ export class RateLimiter {
   }> {
     let lifetime_total_count = await getLocalStorage("lifetime_total_count_mellowtel");
     if (lifetime_total_count === undefined || !lifetime_total_count.hasOwnProperty("lifetime_total_count_mellowtel")) {
-      lifetime_total_count = undefined;
+      lifetime_total_count = 0;
     } else {
       lifetime_total_count = parseInt(lifetime_total_count.lifetime_total_count_mellowtel);
     }

--- a/src/local-rate-limiting/rate-limiter.ts
+++ b/src/local-rate-limiting/rate-limiter.ts
@@ -38,6 +38,26 @@ export class RateLimiter {
     await setLocalStorage("count_mellowtel", count);
   }
 
+  static async getLifetimeTotalCount(): Promise<{
+    lifetime_total_count: number;
+  }> {
+    let lifetime_total_count = await getLocalStorage("lifetime_total_count_mellowtel");
+    if (lifetime_total_count === undefined || !lifetime_total_count.hasOwnProperty("lifetime_total_count_mellowtel")) {
+      lifetime_total_count = undefined;
+    } else {
+      lifetime_total_count = parseInt(lifetime_total_count.lifetime_total_count_mellowtel);
+    }
+    return { lifetime_total_count };
+  }
+
+  static async setHistoricData(
+    initial_timestamp: number,
+    lifetime_total_count: number,
+  ): Promise<void> {
+    await setLocalStorage("initial_timestamp_mellowtel", initial_timestamp);
+    await setLocalStorage("lifetime_total_count_mellowtel", lifetime_total_count);
+  }
+
   static calculateElapsedTime(now: number, timestamp: number): number {
     return now - timestamp;
   }
@@ -71,10 +91,12 @@ export class RateLimiter {
   }> {
     const now = Date.now();
     let { timestamp, count } = await this.getRateLimitData();
+    let { lifetime_total_count } = await this.getLifetimeTotalCount();
 
     if (!timestamp) {
-      Logger.log(`[🕒]: NO_TIMESTAMP, setting timestamp and count`);
+      Logger.log(`[🕒]: NO_TIMESTAMP, setting timestamp, count, and historic data`);
       await this.setRateLimitData(now, 1);
+      await this.setHistoricData(now, 1);
       return {
         shouldContinue: true,
         isLastCount: false,
@@ -94,6 +116,8 @@ export class RateLimiter {
 
     count++;
     await setLocalStorage("count_mellowtel", count);
+    lifetime_total_count++;
+    await setLocalStorage("lifetime_total_count_mellowtel", lifetime_total_count);
     Logger.log(
       `[🕒]: SHOULD CONTINUE? IF COUNT (${count}) <= ${this.MAX_DAILY_RATE} : ${count <= this.MAX_DAILY_RATE}`,
     );


### PR DESCRIPTION
Created two local variables to store the node's historic data. The timestamp when node was initially activated will be stored in initial_timestamp_mellowtel and total request count for the node will be stored in lifetime_total_count_mellowtel .