### PR TITLE
Prevent sending messages to chrome tabs (chrome://)

### DIFF
--- a/src/content-script/shared-memory.ts
+++ b/src/content-script/shared-memory.ts
@@ -59,6 +59,7 @@ export async function getSharedMemoryBCK(key: string) {
       let numTabsChecked: number = 0;
       let mllwtlFramePresent: boolean = false;
       for (let i = 0; i < numTabs; i++) {
+        if (tabs[i]?.url?.includes("chrome://")) return false;
         sendMessageToContentScript(tabs[i].id!, {
           intent: "getSharedMemoryDOM",
           key: key,


### PR DESCRIPTION
This change resolves #6 by adding a condition to skip urls starting with `chrome://`