### PR TITLE
Encode extension ID in URLs

### DIFF
--- a/src/content-script/websocket.ts
+++ b/src/content-script/websocket.ts
@@ -55,7 +55,7 @@ export async function startConnectionWs(identifier: string): WebSocket {
         const manifestVersion = getManifestVersion();
         Logger.log(`[🌐]: Manifest version: ${manifestVersion}`);
         const ws = new WebSocket(
-          `${ws_url}?node_id=${identifier}&version=${VERSION}&chrome_id=${extension_identifier}&speedMbps=${speedMpbs}&browser=${browser}&manifest_version=${manifestVersion}`,
+          `${ws_url}?node_id=${identifier}&version=${VERSION}&chrome_id=${encodeURIComponent(extension_identifier)}&speedMbps=${speedMpbs}&browser=${browser}&manifest_version=${manifestVersion}`,
         );
 
         ws.onopen = function open() {

--- a/src/elements/generate-links.ts
+++ b/src/elements/generate-links.ts
@@ -71,7 +71,7 @@ export function generateAndOpenOptInLink(): Promise<string> {
       let extension_id = await getExtensionIdentifier();
       getIdentifier().then(async (nodeId) => {
         let configuration_key = nodeId.split("_")[1];
-        let link = `${BASE_LINK_OPT_IN}?extension_id=${extension_id}&configuration_key=${configuration_key}`;
+        let link = `${BASE_LINK_OPT_IN}?extension_id=${encodeURIComponent(extension_id)}&configuration_key=${configuration_key}`;
         await setAlreadyOpened("optIn");
         chrome.tabs.create({ url: link });
         resolve(link);
@@ -95,7 +95,7 @@ export function generateAndOpenUpdateLink(): Promise<string> {
       let extension_id = await getExtensionIdentifier();
       getIdentifier().then(async (nodeId) => {
         let configuration_key = nodeId.split("_")[1];
-        let link = `${BASE_LINK_OPT_IN}?extension_id=${extension_id}&configuration_key=${configuration_key}`;
+        let link = `${BASE_LINK_OPT_IN}?extension_id=${encodeURIComponent(extension_id)}&configuration_key=${configuration_key}`;
         await setAlreadyOpened("update");
         chrome.tabs.create({ url: link });
         resolve(link);
@@ -112,7 +112,7 @@ export function generateOptInLink(): Promise<string> {
     getIdentifier().then((nodeId) => {
       let configuration_key = nodeId.split("_")[1];
       resolve(
-        `${BASE_LINK_OPT_IN}?extension_id=${extension_id}&configuration_key=${configuration_key}`,
+        `${BASE_LINK_OPT_IN}?extension_id=${encodeURIComponent(extension_id)}&configuration_key=${configuration_key}`,
       );
     });
   });
@@ -124,7 +124,7 @@ export function generateUpdateLink(): Promise<string> {
     getIdentifier().then((nodeId) => {
       let configuration_key = nodeId.split("_")[1];
       resolve(
-        `${BASE_LINK_UPDATE}?extension_id=${extension_id}&configuration_key=${configuration_key}`,
+        `${BASE_LINK_UPDATE}?extension_id=${encodeURIComponent(extension_id)}&configuration_key=${configuration_key}`,
       );
     });
   });
@@ -136,7 +136,7 @@ export function generateSettingsLink(): Promise<string> {
     getIdentifier().then((nodeId) => {
       let configuration_key = nodeId.split("_")[1];
       resolve(
-        `${BASE_LINK_SETTING}?extension_id=${extension_id}&configuration_key=${configuration_key}`,
+        `${BASE_LINK_SETTING}?extension_id=${encodeURIComponent(extension_id)}&configuration_key=${configuration_key}`,
       );
     });
   });


### PR DESCRIPTION
The extension id generated by AMO for mv2 extensions contains curly braces. It should be encoded when passed in URL params.