### PR TITLE
fix: incorrect control flow into else if branch

### DIFF
--- a/src/permissions/permission-helpers.ts
+++ b/src/permissions/permission-helpers.ts
@@ -57,6 +57,7 @@ export function checkHostPermissionsMV2_3(): Promise<boolean> {
         );
       }
     }
+    resolve(false)
   });
 }
 

--- a/src/permissions/permission-helpers.ts
+++ b/src/permissions/permission-helpers.ts
@@ -101,6 +101,9 @@ export async function checkRequiredPermissions(
         isPermissionPresent = true;
       }
     } else {
+      Logger.log(
+        "checking for declarativeNetRequestWithHostAccess in optional_permissions",
+      );
       if (permission === "declarativeNetRequest") {
         // declarativeNetRequest can't be specified in optional_permissions,
         // so we check for declarativeNetRequestWithHostAccess and add it to permissionsToRequest,


### PR DESCRIPTION
current behavior:
- checkHostPermissionsMV2_3 never resolves, although it should resolve with a boolean
- that way, the program doesn't work propertly
- further, the else condition is never met
- the else condition is required to successfully check optional permissions for declarativeNetRequestWithHostAccess
- the else if condition runs incorrect logic anyways, so it's not needed.
- checkHostPermissionsMV2_3 can simply just resolve with resolve(false) every time

