### PR TITLE
fix: improve content-disposition header handling

### DIFF
--- a/src/utils/triggers-download-helpers.ts
+++ b/src/utils/triggers-download-helpers.ts
@@ -250,8 +250,12 @@ async function fetchAndProcessHeaders(url: string) {
     const contentDisposition = response.headers.get("content-disposition");
     Logger.log("## Content-Disposition:", contentDisposition);
 
-    if (contentDisposition && contentDisposition.indexOf("attachment") === 0) {
-      removeContentDisposition = true;
+    if (contentDisposition) {
+      const contentDispositionLower = contentDisposition.toLowerCase();
+      if (contentDispositionLower.includes("attachment") ||
+          (contentDispositionLower.includes("inline") && contentDispositionLower.includes("filename"))) {
+        removeContentDisposition = true;
+      }
     }
 
     if (contentType) {


### PR DESCRIPTION
## Problem
The extension was incorrectly allowing some files to download when they shouldn't, due to incomplete content-disposition header handling. Specifically:

- Headers starting with whitespace + "attachment" were missed
- Headers using "inline" with a filename parameter could trigger downloads
- Case sensitivity issues meant some headers weren't caught

## (Potential) Solution
Updated the content-disposition header check to:
1. Convert to lowercase for case-insensitive comparison
2. Use `includes()` instead of exact string matching
3. Add logic to catch "inline" dispositions when they include filename parameters

## Testing
No live testing through an extension as I don't know how to manually execute mellowtel to activate and process a file - I haven't looked too deep into the source code. However, the following content-disposition header patterns should now be properly handled:
- `attachment; filename=file.pdf`
- `  attachment; filename=file.pdf`
- `ATTACHMENT; filename="document.docx"`
- `inline; filename="file.txt"`
- `inline; filename*=UTF-8''file.txt`