### PR TITLE
hotfix: add DNR protected initiator domains and update request handling

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,3 +24,14 @@ export const WS_MESSAGE_RATE_LIMIT_TIME_WINDOW: number = 5 * 1000;
 export const SW_PING_INTERVAL: number = 3 * 1000; // 3 seconds
 export const REFRESH_INTERVAL: number = 1000 * 60 * 60 * 24; // 24 hours
 export const SPEED_REFRESH_INTERVAL: number = 1000 * 60 * 60 * 12; // 12 hours
+
+// Hosts whose XHR / sub_frame / image traffic must NEVER be touched by
+// Mellowtel's DNR header-rewrite rules. These are credentialed-XHR sites
+// where forcing `Access-Control-Allow-Origin: *` causes the browser to
+// reject the response (CORS spec forbids `*` for credentialed requests).
+export const DNR_PROTECTED_INITIATOR_DOMAINS: string[] = [
+  // Google video / streaming
+  "youtube.com",
+  "youtube-nocookie.com",
+  "googlevideo.com",
+];

--- a/src/dnr/dnr-helpers.ts
+++ b/src/dnr/dnr-helpers.ts
@@ -3,6 +3,7 @@ import RuleActionType = chrome.declarativeNetRequest.RuleActionType;
 import ResourceType = chrome.declarativeNetRequest.ResourceType;
 import { sendMessageToBackground } from "../utils/messaging-helpers";
 import {
+  DNR_PROTECTED_INITIATOR_DOMAINS,
   RULE_ID_IMAGE_RENDER,
   RULE_ID_POST_REQUEST,
   RULE_ID_XFRAME,
@@ -204,6 +205,7 @@ export function disableHeadersForPOST(): Promise<boolean> {
           condition: {
             urlFilter: "*://*/*",
             resourceTypes: ["xmlhttprequest" as ResourceType],
+            excludedInitiatorDomains: DNR_PROTECTED_INITIATOR_DOMAINS,
           },
         },
       ],


### PR DESCRIPTION
## YouTube Preload/Prefetch Issue

### Issue
The DNR rule used around scrape requests currently matches all XHR traffic globally, which can briefly affect credentialed XHR on other tabs while a scrape is in flight (notably YouTube preloading from googlevideo.com, where CORS forbids Access-Control-Allow-Origin: * on credentialed responses).

### Fix
This PR adds excludedInitiatorDomains to the rule so it skips requests initiated by a small list of credentialed-XHR sites. SDK scrape behavior is unchanged. The list is intentionally minimal and easy to extend; the longer-term plan is per-URL rule scoping with redirect tracking, after which this list can be removed.